### PR TITLE
feat: make minimal prettier plugin that works well

### DIFF
--- a/packages/prettier/.prettierrc.json
+++ b/packages/prettier/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "useTabs": true,
+    "singleQuote": true
+}

--- a/packages/prettier/.vscode/settings.json
+++ b/packages/prettier/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+    },
+    "[vue]": {
+        "editor.defaultFormatter": "johnsoncodehk.volar",
+        "editor.formatOnSave": true
+    },
+    "vetur.validation.template": false,
+    "vetur.validation.script": false,
+    "vetur.validation.style": false,
+    "editor.tabSize": 4
+}

--- a/packages/prettier/README.md
+++ b/packages/prettier/README.md
@@ -1,0 +1,34 @@
+# @volar-plugins/prettier
+
+> [Volar](https://github.com/johnsoncodehk/volar) plugin for [prettier](https://prettier.io/).
+
+## Usage
+
+`package.json`
+
+```json
+{
+  "devDependencies": {
+    "@volar-plugins/prettier": "latest"
+  }
+}
+```
+
+`volar.config.js`
+
+```js
+/** @type {import('@volar-plugins/prettier')} */
+const { volarPrettierPlugin } = require('@volar-plugins/prettier');
+
+module.exports = {
+	plugins: [
+		volarPrettierPlugin({
+			languages: ['html', 'css', 'scss', 'less', 'typescript', 'javascript'],
+			html: {
+				keepLongTemplates: true,
+				breakContentsFromTags: true,
+			},
+		}),
+	],
+};
+```

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -13,14 +13,15 @@
 		"directory": "packages/prettier"
 	},
 	"scripts": {
-		"build": "tsc"
+		"build": "tsc --rootDir src --outDir out"
 	},
 	"devDependencies": {
-		"@types/prettier": "^2.6.0"
+		"@types/prettier": "^2.6.0",
+		"vue": "^3.2.33"
 	},
 	"dependencies": {
 		"@volar/vue-language-service-types": "^0.34.0",
-        "prettier": "^2.6.2",
+		"prettier": "^2.6.2",
 		"typescript": "^4.6.3",
 		"vscode-uri": "^3.0.3"
 	}

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -3,6 +3,11 @@
 	"version": "1.0.1",
 	"main": "out/index.js",
 	"license": "MIT",
+	"author": {
+		"name": "Pacharapol Withayasakpunt",
+		"email": "polv@polv.cc",
+		"url": "https://www.polv.cc"
+	},
 	"files": [
 		"out/**/*.js",
 		"out/**/*.d.ts"
@@ -15,14 +20,14 @@
 	"scripts": {
 		"build": "tsc --rootDir src --outDir out"
 	},
+	"dependencies": {
+		"prettier": "^2.6.2",
+		"vscode-uri": "^3.0.3"
+	},
 	"devDependencies": {
 		"@types/prettier": "^2.6.0",
-		"vue": "^3.2.33"
-	},
-	"dependencies": {
 		"@volar/vue-language-service-types": "^0.34.0",
-		"prettier": "^2.6.2",
 		"typescript": "^4.6.3",
-		"vscode-uri": "^3.0.3"
+		"vue": "^3.2.33"
 	}
 }

--- a/packages/prettier/src/index.ts
+++ b/packages/prettier/src/index.ts
@@ -1,34 +1,126 @@
-import type { EmbeddedLanguageServicePlugin } from '@volar/vue-language-service-types';
-import * as prettier from 'prettier';
-import { URI } from 'vscode-uri';
+import { randomUUID } from 'crypto';
 
-export default function (configs: {
-	languages: string[],
-}): EmbeddedLanguageServicePlugin {
+import type { EmbeddedLanguageServicePlugin } from '@volar/vue-language-service-types';
+import { format, resolveConfigFile, resolveConfig, Options } from 'prettier';
+import { URI } from 'vscode-uri';
+import { writeFileSync } from 'fs';
+
+export interface VolarPrettierConfig {
+	/**
+	 * Languages to be formatted by prettier.
+	 *
+	 * @default
+	 * ['html', 'css', 'scss', 'less', 'typescript', 'javascript']
+	 */
+	languages?: string[];
+	html?: {
+		/**
+		 * Prettier breaks {{'...long line...'}} in <template> tags.
+		 * This should work as a temporary fix.
+		 *
+		 * @default
+		 * true
+		 */
+		keepLongTemplates?: boolean;
+		/**
+		 * An opinionated option of breaking "contents" from "HTML tags".
+		 * This will probably prevent HTML closing tags, and opening tags without attributes
+		 * from breaking into blank `>` on a new line.
+		 *
+		 * @default
+		 * false
+		 */
+		breakContentsFromTags?: boolean;
+	};
+}
+
+export const defaultConfig: VolarPrettierConfig = {
+	languages: ['html', 'css', 'scss', 'less', 'typescript', 'javascript'],
+	html: {
+		keepLongTemplates: true,
+		breakContentsFromTags: false,
+	},
+};
+
+function mapDefault<T>(o: T, d: T): T {
+	Object.keys(d).map((k) => {
+		if (typeof o[k] === 'undefined') {
+			o[k] = d[k];
+		}
+		if (d[k] instanceof Object) {
+			mapDefault(o[k], d[k]);
+		}
+	});
+	return o;
+}
+
+export const volarPrettierPlugin: (
+	config: VolarPrettierConfig
+) => EmbeddedLanguageServicePlugin = (config = {}) => {
+	mapDefault(config, defaultConfig);
+
+	let prettierConfig: Options = {};
+	try {
+		prettierConfig = resolveConfig.sync(resolveConfigFile.sync());
+	} catch (e) {}
+
+	const makeUUID = () => `{{'${randomUUID()}'}}`;
+	const uuidRegex = (() => {
+		const c = '[0-9a-f]';
+		return new RegExp(makeUUID().replace(new RegExp(c, 'g'), c), 'g');
+	})();
 
 	return {
-
 		format(document, range, options) {
+			if (!config.languages.includes(document.languageId)) return;
 
-			if (!configs.languages.includes(document.languageId))
-				return;
+			let oldText = document.getText(range);
 
-			const oldText = document.getText(range);
-			let newText = prettier.format(oldText, {
-				tabWidth: options.tabSize,
-				useTabs: !options.insertSpaces,
+			const isHTML = document.languageId === 'html';
+			const isKeepLongHTMLTemplates = isHTML
+				? config.html?.keepLongTemplates
+				: false;
+			const noBreak = new Map();
+			if (isKeepLongHTMLTemplates) {
+				oldText = oldText.replace(
+					/( *){{ *((['"])[^]+?\3) *}}( *)/g,
+					(raw, w1, content, _bracket, w2) => {
+						const id = makeUUID();
+						raw = `{{ ${content} }}`;
+						noBreak.set(id, raw);
+						return w1 + id + w2;
+					}
+				);
+			}
+
+			if (isHTML && config.html.breakContentsFromTags) {
+				oldText = oldText
+					.replace(/(<[a-z][^>]*>) ?(.)/gi, '$1 $2')
+					.replace(/(.) ?(<\/[a-z][a-z0-9\t\n\r -]*>)/gi, '$1 $2');
+			}
+
+			let newText = format(oldText, {
+				...prettierConfig,
 				filepath: URI.parse(document.uri).fsPath,
 			});
 
+			if (isKeepLongHTMLTemplates) {
+				newText = newText.replace(uuidRegex, (raw) => {
+					return noBreak.get(raw) || raw;
+				});
+			}
+
 			newText = '\n' + newText.trim() + '\n';
 
-			if (newText === oldText)
-				return [];
-
-			return [{
-				range: range,
-				newText: newText,
-			}];
+			if (newText === oldText) return [];
+			return [
+				{
+					range: range,
+					newText: newText,
+				},
+			];
 		},
-	}
-}
+	};
+};
+
+export default volarPrettierPlugin;

--- a/packages/prettier/src/index.ts
+++ b/packages/prettier/src/index.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'crypto';
 import type { EmbeddedLanguageServicePlugin } from '@volar/vue-language-service-types';
 import { format, resolveConfigFile, resolveConfig, Options } from 'prettier';
 import { URI } from 'vscode-uri';
-import { writeFileSync } from 'fs';
 
 export interface VolarPrettierConfig {
 	/**

--- a/packages/prettier/tests/TypeScriptHtmlCss.vue
+++ b/packages/prettier/tests/TypeScriptHtmlCss.vue
@@ -1,0 +1,54 @@
+<template>
+	<h1>{{ msg }}</h1>
+
+	<p>
+		Recommended IDE setup:
+		<a href="https://code.visualstudio.com/" target="_blank"> VSCode </a>
+		+
+		<a href="https://github.com/johnsoncodehk/volar" target="_blank"> Volar </a>
+	</p>
+
+	<p>
+		<a href="https://vitejs.dev/guide/features.html" target="_blank">
+			Vite Docs
+		</a>
+		|
+		<a href="https://v3.vuejs.org/" target="_blank"> Vue 3 Docs </a>
+	</p>
+
+	<button @click="count++">count is: {{ count }}</button>
+	<p>
+		Edit
+		<code> components/HelloWorld.vue </code> to test hot module replacement.
+	</p>
+
+	{{ 'a very loooooooooooooooooooooooooooooooooooooooooooooo00000000000000000ooong text' }}
+</template>
+
+<preview msg="Hello Volar!"></preview>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+defineProps<{ msg: string }>();
+
+const count = ref(0);
+</script>
+
+<style scoped>
+a {
+	color: #42b983;
+}
+
+label {
+	margin: 0 0.5em;
+	font-weight: bold;
+}
+
+code {
+	background-color: #eee;
+	padding: 2px 4px;
+	border-radius: 4px;
+	color: #304455;
+}
+</style>

--- a/packages/prettier/tests/TypeScriptHtmlCss.vue.html
+++ b/packages/prettier/tests/TypeScriptHtmlCss.vue.html
@@ -1,0 +1,51 @@
+<template>
+  <h1>{{ msg }}</h1>
+
+  <p>
+    Recommended IDE setup:
+    <a href="https://code.visualstudio.com/" target="_blank">VSCode</a>
+    +
+    <a href="https://github.com/johnsoncodehk/volar" target="_blank">Volar</a>
+  </p>
+
+  <p>
+    <a href="https://vitejs.dev/guide/features.html" target="_blank">Vite Docs</a> |
+    <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Docs</a>
+  </p>
+
+  <button @click="count++">count is: {{ count }}</button>
+  <p>
+    Edit
+    <code>components/HelloWorld.vue</code> to test hot module replacement.
+  </p>
+
+  {{ 'a very loooooooooooooooooooooooooooooooooooooooooooooo00000000000000000ooong text' }}
+</template>
+
+<preview msg="Hello Volar!"></preview>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+defineProps<{ msg: string }>()
+
+const count = ref(0)
+</script>
+
+<style scoped>
+a {
+  color: #42b983;
+}
+
+label {
+  margin: 0 0.5em;
+  font-weight: bold;
+}
+
+code {
+  background-color: #eee;
+  padding: 2px 4px;
+  border-radius: 4px;
+  color: #304455;
+}
+</style>

--- a/packages/prettier/tsconfig.json
+++ b/packages/prettier/tsconfig.json
@@ -1,8 +1,6 @@
 {
 	"compilerOptions": {
 		"lib": ["ESNext"],
-		"outDir": "out",
-		"rootDir": "src",
 		"declaration": true,
 	},
 	"include": [

--- a/packages/prettier/volar.config.js
+++ b/packages/prettier/volar.config.js
@@ -1,0 +1,14 @@
+/** @type {import('./src')} */
+const { volarPrettierPlugin } = require('./out');
+
+module.exports = {
+	plugins: [
+		volarPrettierPlugin({
+			languages: ['html', 'css', 'scss', 'less', 'typescript', 'javascript'],
+			html: {
+				keepLongTemplates: true,
+				breakContentsFromTags: true,
+			},
+		}),
+	],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       vscode-uri: ^3.0.3
       vue: ^3.2.33
     dependencies:
-      '@volar/vue-language-service-types': 0.34.6
       prettier: 2.6.2
-      typescript: 4.6.3
       vscode-uri: 3.0.3
     devDependencies:
       '@types/prettier': 2.6.0
+      '@volar/vue-language-service-types': 0.34.6
+      typescript: 4.6.3
       vue: 3.2.33
 
   packages/prettier-html:
@@ -194,7 +194,6 @@ packages:
     dependencies:
       vscode-languageserver-protocol: 3.17.0-next.16
       vscode-languageserver-textdocument: 1.0.4
-    dev: false
 
   /@vue/compiler-core/3.2.33:
     resolution: {integrity: sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==}
@@ -1563,7 +1562,6 @@ packages:
     resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /unified-engine/6.0.1:
     resolution: {integrity: sha512-iDJYH82TgcezQA4IZzhCNJQx7vBsGk4h9s4Q7Fscrb3qcPsxBqVrVNYez2W3sBVTxuU1bFAhyRpA6ba/R4j93A==}
@@ -1778,22 +1776,18 @@ packages:
   /vscode-jsonrpc/8.0.0-next.7:
     resolution: {integrity: sha512-JX/F31LEsims0dAlOTKFE4E+AJMiJvdRSRViifFJSqSN7EzeYyWlfuDchF7g91oRNPZOIWfibTkDf3/UMsQGzQ==}
     engines: {node: '>=14.0.0'}
-    dev: false
 
   /vscode-languageserver-protocol/3.17.0-next.16:
     resolution: {integrity: sha512-tx4DnXw9u3N7vw+bx6n2NKp6FoxoNwiP/biH83AS30I2AnTGyLd7afSeH6Oewn2E8jvB7K15bs12sMppkKOVeQ==}
     dependencies:
       vscode-jsonrpc: 8.0.0-next.7
       vscode-languageserver-types: 3.17.0-next.9
-    dev: false
 
   /vscode-languageserver-textdocument/1.0.4:
     resolution: {integrity: sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==}
-    dev: false
 
   /vscode-languageserver-types/3.17.0-next.9:
     resolution: {integrity: sha512-9/PeDNPYduaoXRUzYpqmu4ZV9L01HGo0wH9FUt+sSHR7IXwA7xoXBfNUlv8gB9H0D2WwEmMomSy1NmhjKQyn3A==}
-    dev: false
 
   /vscode-uri/3.0.3:
     resolution: {integrity: sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ importers:
       prettier: ^2.6.2
       typescript: ^4.6.3
       vscode-uri: ^3.0.3
+      vue: ^3.2.33
     dependencies:
       '@volar/vue-language-service-types': 0.34.6
       prettier: 2.6.2
@@ -19,6 +20,7 @@ importers:
       vscode-uri: 3.0.3
     devDependencies:
       '@types/prettier': 2.6.0
+      vue: 3.2.33
 
   packages/prettier-html:
     specifiers:
@@ -31,6 +33,12 @@ importers:
       typescript: 4.6.3
 
 packages:
+
+  /@babel/parser/7.17.9:
+    resolution: {integrity: sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dev: true
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -187,6 +195,89 @@ packages:
       vscode-languageserver-protocol: 3.17.0-next.16
       vscode-languageserver-textdocument: 1.0.4
     dev: false
+
+  /@vue/compiler-core/3.2.33:
+    resolution: {integrity: sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==}
+    dependencies:
+      '@babel/parser': 7.17.9
+      '@vue/shared': 3.2.33
+      estree-walker: 2.0.2
+      source-map: 0.6.1
+    dev: true
+
+  /@vue/compiler-dom/3.2.33:
+    resolution: {integrity: sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==}
+    dependencies:
+      '@vue/compiler-core': 3.2.33
+      '@vue/shared': 3.2.33
+    dev: true
+
+  /@vue/compiler-sfc/3.2.33:
+    resolution: {integrity: sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==}
+    dependencies:
+      '@babel/parser': 7.17.9
+      '@vue/compiler-core': 3.2.33
+      '@vue/compiler-dom': 3.2.33
+      '@vue/compiler-ssr': 3.2.33
+      '@vue/reactivity-transform': 3.2.33
+      '@vue/shared': 3.2.33
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+      postcss: 8.4.12
+      source-map: 0.6.1
+    dev: true
+
+  /@vue/compiler-ssr/3.2.33:
+    resolution: {integrity: sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.33
+      '@vue/shared': 3.2.33
+    dev: true
+
+  /@vue/reactivity-transform/3.2.33:
+    resolution: {integrity: sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==}
+    dependencies:
+      '@babel/parser': 7.17.9
+      '@vue/compiler-core': 3.2.33
+      '@vue/shared': 3.2.33
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+    dev: true
+
+  /@vue/reactivity/3.2.33:
+    resolution: {integrity: sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==}
+    dependencies:
+      '@vue/shared': 3.2.33
+    dev: true
+
+  /@vue/runtime-core/3.2.33:
+    resolution: {integrity: sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==}
+    dependencies:
+      '@vue/reactivity': 3.2.33
+      '@vue/shared': 3.2.33
+    dev: true
+
+  /@vue/runtime-dom/3.2.33:
+    resolution: {integrity: sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==}
+    dependencies:
+      '@vue/runtime-core': 3.2.33
+      '@vue/shared': 3.2.33
+      csstype: 2.6.20
+    dev: true
+
+  /@vue/server-renderer/3.2.33_vue@3.2.33:
+    resolution: {integrity: sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==}
+    peerDependencies:
+      vue: 3.2.33
+    dependencies:
+      '@vue/compiler-ssr': 3.2.33
+      '@vue/shared': 3.2.33
+      vue: 3.2.33
+    dev: true
+
+  /@vue/shared/3.2.33:
+    resolution: {integrity: sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==}
+    dev: true
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -398,6 +489,10 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /csstype/2.6.20:
+    resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
+    dev: true
+
   /currently-unhandled/0.4.1:
     resolution: {integrity: sha1-mI3zP+qxke95mmE2nddsF635V+o=}
     engines: {node: '>=0.10.0'}
@@ -481,6 +576,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     dev: false
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
 
   /execa/0.7.0:
     resolution: {integrity: sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=}
@@ -881,6 +980,12 @@ packages:
       yallist: 2.1.2
     dev: false
 
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /make-dir/1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
     engines: {node: '>=4'}
@@ -939,6 +1044,12 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: false
+
+  /nanoid/3.3.2:
+    resolution: {integrity: sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
 
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -1057,10 +1168,23 @@ packages:
       pify: 3.0.0
     dev: false
 
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
+
   /pify/3.0.0:
     resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
     engines: {node: '>=4'}
     dev: false
+
+  /postcss/8.4.12:
+    resolution: {integrity: sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.2
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
 
   /prepend-http/2.0.0:
     resolution: {integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=}
@@ -1244,6 +1368,20 @@ packages:
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: false
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -1660,6 +1798,16 @@ packages:
   /vscode-uri/3.0.3:
     resolution: {integrity: sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==}
     dev: false
+
+  /vue/3.2.33:
+    resolution: {integrity: sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.33
+      '@vue/compiler-sfc': 3.2.33
+      '@vue/runtime-dom': 3.2.33
+      '@vue/server-renderer': 3.2.33_vue@3.2.33
+      '@vue/shared': 3.2.33
+    dev: true
 
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,9 @@ module.exports = {
 
 prettier:
 
+`package.json`
+
 ```json
-// package.json
 {
   "devDependencies": {
     "@volar-plugins/prettier": "latest"
@@ -35,11 +36,21 @@ prettier:
 }
 ```
 
+`volar.config.js`
+
 ```js
-// vetur.config.js
+/** @type {import('@volar-plugins/prettier')} */
+const { volarPrettierPlugin } = require('@volar-plugins/prettier');
+
 module.exports = {
-    plugins: [
-        require('@volar-plugins/prettier').default({ languages: ['html', 'css', 'scss', 'less'] }),
-    ],
+	plugins: [
+		volarPrettierPlugin({
+			languages: ['html', 'css', 'scss', 'less', 'typescript', 'javascript'],
+			html: {
+				keepLongTemplates: true,
+				breakContentsFromTags: true,
+			},
+		}),
+	],
 };
 ```


### PR DESCRIPTION
Also, add options for

- `keepLongTemplates: true` - HTML template will sometimes break without this option
- `breakContentsFromTags: true` - convenience beyond HTML prettier (AFAIK)

Some suggestions

- `/readme.md` (Readme at root) got typo for `vetur.config.js` (see my fix)
- Move filename out of \`\`\`json block

![Red filename](https://user-images.githubusercontent.com/21255931/163586867-3c79967a-87c4-4d19-b21c-3f3e9d29ee33.png)

- Plugin doesn't have to be `default` export (see my fix)